### PR TITLE
Added support for dmaker.fan.p5 model

### DIFF
--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -21,14 +21,24 @@ class FanXiaomi extends HTMLElement {
 
         const attrs = state.attributes;
 
+        let p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
+        let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
+        let model = attrs['model']
+        let speed_list
+        if (model === 'dmaker.fan.p5') {
+            speed_list = p5_speed_list
+        } else {
+            speed_list = za4_speed_list
+        }
+        
         if (!this.card) {
             const card = document.createElement('ha-card');
             card.className = 'fan-xiaomi'
 
-            // 创建UI
+            // Create UI
             card.appendChild(ui)
 
-            //调整风扇角度事件绑定
+            //Adjust fan angle event binding
             ui.querySelector('.left').onmouseover = () => {
                 ui.querySelector('.left').classList.replace('hidden','show')
             }
@@ -60,7 +70,7 @@ class FanXiaomi extends HTMLElement {
                 }
                 return false;
             }
-            // 定义事件
+            // Define the event
             ui.querySelector('.c1').onclick = () => {
                 this.log('Toggle')
                 hass.callService('fan', 'toggle', {
@@ -75,19 +85,24 @@ class FanXiaomi extends HTMLElement {
                     let icon = u.querySelector('.icon-waper > iron-icon')
                     let newSpeed
                     if (icon.getAttribute('icon') == "mdi:numeric-1-box-outline") {
-                        newSpeed = 40
+                        newSpeed = speed_list['Level 2']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
-                        newSpeed = 60
+                        newSpeed = speed_list['Level 3']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-3-box-outline") {
-                        newSpeed = 80
+                        newSpeed = speed_list['Level 4']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        newSpeed = 100
-                        iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
+                        if (model === 'dmaker.fan.p5') { // For p5 last speed is Level 4
+                            newSpeed = speed_list['Level 1']
+                            iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
+                        } else {
+                            newSpeed = speed_list['Level 5']
+                            iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
+                        }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {
-                        newSpeed = 20
+                        newSpeed = speed_list['Level 1']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                     } else {
                         this.log('Error setting fan speed')
@@ -172,13 +187,13 @@ class FanXiaomi extends HTMLElement {
                 }
             }
             ui.querySelector('.var-title').onclick = () => {
-                this.log('对话框')
+                this.log('Dialog box')
                 card.querySelector('.dialog').style.display = 'block'
             }
             this.card = card;
             this.appendChild(card);
         }
-        //设置值更新UI
+        //Set value update UI
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {
             title: myname || attrs['friendly_name'],
             natural_speed: attrs['natural_speed'],
@@ -188,7 +203,10 @@ class FanXiaomi extends HTMLElement {
             oscillating: attrs['oscillating'],
             led_brightness: attrs['led_brightness'],
             delay_off_countdown: attrs['delay_off_countdown'],
-            angle: attrs['angle']
+            angle: attrs['angle'],
+            speed: attrs['speed'],
+            model: attrs['model'],
+            speed_list: speed_list
         })
     }
 
@@ -205,7 +223,7 @@ class FanXiaomi extends HTMLElement {
         return 1;
     }
 
-    /*********************************** UI设置 ************************************/
+    /*********************************** UI settings ************************************/
     getUI() {
 
         let csss='';
@@ -282,7 +300,7 @@ to{transform:perspective(10em) rotateY(40deg)}
 
 </style>
 <div class="title">
-<p class="var-title">儿童房</p>
+<p class="var-title">Playground</p>
 </div>
 <div class="fanbox">
 <div class="blades ">
@@ -353,9 +371,10 @@ Natural
         return fanbox
     }
 
-    // 设置UI值
+    // Set the UI value
     setUI(fanboxa, {title, natural_speed, direct_speed, state,
-        child_lock, oscillating, led_brightness, delay_off_countdown, angle
+        child_lock, oscillating, led_brightness, delay_off_countdown, angle, 
+        speed, model, speed_list
     }) {
 
         fanboxa.querySelector('.var-title').textContent = title
@@ -416,13 +435,18 @@ Natural
             // iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-0-box-outline"></iron-icon>'
         }
         let direct_speed_int = Number(direct_speed)
-        if (direct_speed_int <= 20) {
+        
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed
+            direct_speed_int = speed_list[speed]
+        }
+        
+        if (direct_speed_int <= speed_list['Level 1']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 40) {
+        } else if (direct_speed_int <= speed_list['Level 2']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 60) {
+        } else if (direct_speed_int <= speed_list['Level 3']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 80) {
+        } else if (direct_speed_int <= speed_list['Level 4']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
         } else {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
@@ -453,9 +477,9 @@ Natural
             fb.classList.remove('oscillation')
         }
     }
-/*********************************** UI设置 ************************************/
+/*********************************** UI Set up ************************************/
 
-    // 加入日志开关l
+    // Add log switch
     log() {
         // console.log(...arguments)
     }


### PR DESCRIPTION
p5 model does not report current direct_speed at which it's operating, so need to use Levels 1-4 which miio reports back to us.
Because p5 reporting only 4 levels, need to loop from 4th level back to 1st. That's the reason levels are different from za4 as well.
In order to support p5 and za4 simultaniusly, added speed_list array.
According to my plan, it should work for za4 as before.